### PR TITLE
Hi, Dave!

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -50,6 +50,14 @@ if (!defined('MPM_METHOD_MYSQLI'))
     define('MPM_METHOD_MYSQLI', 2);
 }
 
+if (!defined('STDIN'))
+{
+    /**
+     * In some cases STDIN built-in can be undefined
+     */
+    define('STDIN', fopen("php://stdin","r"));
+}
+
 /**
  * Include the MpmClassUndefinedException class.
  */


### PR DESCRIPTION
There are some cases when STDIN built-in constant can be undefined, so init controller fall into an infinite loop.
I've added a little bugfix in init.php to support STDIN.
